### PR TITLE
Fixed issue with missing steam games

### DIFF
--- a/src/components/core/games/Game.svelte
+++ b/src/components/core/games/Game.svelte
@@ -20,7 +20,7 @@
   $: steamLogoPos = $steamLogoPositions[game.appid]?.logoPosition;
   $: canDiscard = (($currentPlatform == Platforms.STEAM && $appLibraryCache[game.appid]) ? $appLibraryCache[game.appid][$gridType] != $originalAppLibraryCache[game.appid][$gridType] : false)
                   || (steamLogoPos ? (steamLogoPos.nHeightPct != originalLogoPos?.nHeightPct || steamLogoPos.nWidthPct != originalLogoPos?.nWidthPct || steamLogoPos.pinnedPosition != originalLogoPos?.pinnedPosition) : false);
-  $: hasCustomArt = ($currentPlatform == Platforms.STEAM && $unfilteredLibraryCache[game?.appid]) ? $appLibraryCache[game?.appid][$gridType] != $unfilteredLibraryCache[game?.appid][$gridType] : false;
+  $: hasCustomArt = ($currentPlatform == Platforms.STEAM && $unfilteredLibraryCache[game.appid]) ? $appLibraryCache[game.appid][$gridType] != $unfilteredLibraryCache[game.appid][$gridType] : false;
 
   /**
    * Selects this game.

--- a/src/components/core/games/Game.svelte
+++ b/src/components/core/games/Game.svelte
@@ -20,7 +20,7 @@
   $: steamLogoPos = $steamLogoPositions[game.appid]?.logoPosition;
   $: canDiscard = (($currentPlatform == Platforms.STEAM && $appLibraryCache[game.appid]) ? $appLibraryCache[game.appid][$gridType] != $originalAppLibraryCache[game.appid][$gridType] : false)
                   || (steamLogoPos ? (steamLogoPos.nHeightPct != originalLogoPos?.nHeightPct || steamLogoPos.nWidthPct != originalLogoPos?.nWidthPct || steamLogoPos.pinnedPosition != originalLogoPos?.pinnedPosition) : false);
-  $: hasCustomArt = ($currentPlatform == Platforms.STEAM && $unfilteredLibraryCache[game.appid]) ? $appLibraryCache[game.appid][$gridType] != $unfilteredLibraryCache[game.appid][$gridType] : false;
+  $: hasCustomArt = ($currentPlatform == Platforms.STEAM && $unfilteredLibraryCache[game?.appid]) ? $appLibraryCache[game?.appid][$gridType] != $unfilteredLibraryCache[game?.appid][$gridType] : false;
 
   /**
    * Selects this game.

--- a/src/lib/controllers/AppController.ts
+++ b/src/lib/controllers/AppController.ts
@@ -448,7 +448,8 @@ export class AppController {
     const filteredKeys = Object.keys(filteredCache);
 
     if (online && !needsSteamAPIKey) {
-      const apiGames = (await this.getGamesFromSteamAPI(bUserId)).filter((entry: GameStruct) => filteredKeys.includes(entry.appid.toString()));
+      const apiGames = (await this.getGamesFromSteamAPI(bUserId));
+
       console.log("Steam API Games:", apiGames);
       steamGames.set(apiGames);
       

--- a/src/lib/controllers/AppController.ts
+++ b/src/lib/controllers/AppController.ts
@@ -286,8 +286,8 @@ export class AppController {
 
     const entries = Object.entries(res);
     unfilteredLibraryCache.set(JSON.parse(JSON.stringify(unfiltered)));
-    const filtered = entries.filter(([appId, entry]) => Object.keys(entry).length >= 4 || shortcutIds.includes(appId));
-    return Object.fromEntries(filtered);
+    // const filtered = entries.filter(([appId, entry]) => Object.keys(entry).length >= 4 || shortcutIds.includes(appId));
+    return Object.fromEntries(entries);
   }
 
   /**

--- a/src/lib/controllers/AppController.ts
+++ b/src/lib/controllers/AppController.ts
@@ -448,8 +448,7 @@ export class AppController {
     const filteredKeys = Object.keys(filteredCache);
 
     if (online && !needsSteamAPIKey) {
-      const apiGames = (await this.getGamesFromSteamAPI(bUserId));
-
+      const apiGames = (await this.getGamesFromSteamAPI(bUserId)).filter((entry: GameStruct) => filteredKeys.includes(entry.appid.toString()));
       console.log("Steam API Games:", apiGames);
       steamGames.set(apiGames);
       


### PR DESCRIPTION
When using the application on my machine, with a pretty big library (700+ games) it only shows around 200/300 of the games. And each time I restart the app it loads a few games extra.

I was able to pinpoint the issue to the list op games being filtered on what is available in the cache. A list built up by files found in my steam folder. But since this cache only returns games with actual custom artwork, it will filter out any games that have not yet gotten custom artwork.

Can't say I understand the code 100%, so please check it before accepting. But when running the app with this fix, on my machine, it lists all the games at once. And I'm not sure how and where you want the fixes in your repository, so feel free to give feedback on this.