### PR TITLE
add appimage script

### DIFF
--- a/appimage-webkit.sh
+++ b/appimage-webkit.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# this script takes the deb made by tauri a makes a proper appimage that bundles webkigtk
+# and all dependencies, so the resulting appimage actually works on any linux system
+
+set -eu
+
+export ARCH="$(uname -m)"
+export APPIMAGE_EXTRACT_AND_RUN=1
+
+UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
+APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+LIB4BIN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
+SARM_URL=$(wget --retry-connrefused --tries=30 \
+	https://api.github.com/repos/Tormak9970/Steam-Art-Manager/releases -O - \
+	| sed 's/[()",{} ]/\n/g' | grep -oi "https.*amd64.deb$" | head -1)
+
+mkdir ./AppDir
+cd ./AppDir
+
+# Unpack the deb
+wget --retry-connrefused --tries=30 "$SARM_URL" -O ./sarm.deb
+ar vx sarm.deb
+tar -xvf data.tar.gz
+rm -f *.tar* sarm.deb debian-binary
+mv ./usr/share ./
+cp ./share/applications/*.desktop ./
+cp ./share/icons/hicolor/256x256/apps/app.png ./
+ln -s ./app.png ./.DirIcon
+
+# Bundle all libs we have to include opengl for webkigtk
+wget --retry-connrefused --tries=30 "$LIB4BIN" -O ./lib4bin
+chmod +x ./lib4bin
+./lib4bin -p -v -r -s -k ./usr/bin/app \
+	/usr/lib/x86_64-linux-gnu/libGL* \
+	/usr/lib/x86_64-linux-gnu/libEGL* \
+	/usr/lib/x86_64-linux-gnu/libvulkan* \
+	/usr/lib/x86_64-linux-gnu/dri/* \
+	/usr/lib/x86_64-linux-gnu/gstreamer-1.0/* \
+	/usr/lib/x86_64-linux-gnu/libpulsecommon* \
+	/usr/lib/x86_64-linux-gnu/libnss_mdns*
+rm -rf ./usr
+
+# Add gstreamer binaries
+cp -vr /usr/lib/x86_64-linux-gnu/gstreamer1.0/*/* ./shared/bin
+( cd ./shared/lib/gstreamer-1.0
+	ln -s ../../../sharun ./gst-plugin-scanner
+	ln -s ../../../sharun ./gst-ptp-helper
+)
+
+# Bundle webkitgtk
+# We need to wrap the webkitgtk binaries with sharun, so they go in bin
+cp -vr /usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/* ./shared/bin
+
+# Now symlink them from their "typical" location
+mkdir -p ./shared/lib/webkit2gtk-4.1/injected-bundle
+( cd ./shared/lib/webkit2gtk-4.1
+	ln -s ../../../sharun ./WebKitWebProcess
+	ln -s ../../../sharun ./WebKitNetworkProcess
+	ln -s ../../../sharun ./MiniBrowser
+	cd ./injected-bundle
+	cp -v ../../../../shared/bin/injected-bundle/* ./
+)
+ln -s ./ ./shared/lib/x86_64-linux-gnu
+
+# Now we need to patch away the hardcoded path from the webkitgtk libraries
+# Ideally something like ld-preload-open should be used
+# but webkitgtk is so amazing that even that does not work
+find ./shared/lib -name 'libwebkit*' -exec sed -i 's|/usr|././|g' {} \;
+echo 'SHARUN_WORKING_DIR=${SHARUN_DIR}' > ./.env
+
+# Prepare sharun
+ln ./sharun ./AppRun
+./sharun -g
+
+# Make appimage
+cd ..
+wget -q "$APPIMAGETOOL" -O ./appimagetool
+chmod +x ./appimagetool
+./appimagetool --comp zstd \
+	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+	-n -u "$UPINFO" "$PWD"/AppDir "$PWD"/Steam-Art-Manager-anylinux-"$ARCH".AppImage
+
+echo "All done!"
+


### PR DESCRIPTION
Hi, the following script will produce an appimage that bundles all the deps and also handles webkitgtk. 

However as you can see I wrote the script to directly download the `.deb` from the releases instead of modifying the .yml to call the script and tell the script the location of the deb file. 

All that's needed for the script are the same 24.04 runner and dependencies that area already installed in the CI + patchelf, binutils, gstreamer, pulseaudio, vulkan and opengl. 

So I would really appreciate help to configure tauri to stop making the appimage and only the deb and also to not releases instantly to allow this script to be changed to run on the directly produced deb instead of downloading it. 
