### PR TITLE
Do not filter entries in the appinfo VDF parser

### DIFF
--- a/crates/new-vdf-parser/src/appinfo_vdf_parser.rs
+++ b/crates/new-vdf-parser/src/appinfo_vdf_parser.rs
@@ -93,19 +93,8 @@ fn read_app_sections(reader: &mut Reader, string_table_offset: Option<i64>, magi
       entry = appinfo.clone();
     }
 
-    if entry.contains_key("common") {
-      let common_val: &Value = entry.get("common").expect("Should have been able to get \"common\".");
-      let common = common_val.as_object().expect("Common should have been an object.");
-      
-      let type_val: &Value = common.get("type").expect("Should have been able to get \"common\".\"type\".");
-      let type_str: &str = type_val.as_str().expect("Should have been able to convert type to str");
+    return Some(Value::Object(entry));
 
-      if type_str == "Game" || type_str == "game" {
-        return Some(Value::Object(entry));
-      }
-    }
-
-    return None;
   }).collect();
 
   return entries;

--- a/src/lib/controllers/SteamController.ts
+++ b/src/lib/controllers/SteamController.ts
@@ -40,7 +40,7 @@ export class SteamController {
 
     const vdf = await RustInterop.readAppinfoVdf();
 
-    return vdf.entries.filter((entry: any) => ids.includes(entry.appid)).map((entry: any) => {
+    return vdf.entries.filter((entry: any) => ids.includes(entry.appid) && entry.common.type.toLowerCase() == "game").map((entry: any) => {
       const libraryAssets = entry.common.library_assets_full;
       
       return {


### PR DESCRIPTION
Since the VDF parser is now a standalone crate, I thought I'd do this. These changes are needed for Luxtorpeda.

I've tested my changes on Steam-Art-Manager and it works fine 